### PR TITLE
Fix CVE-2024-43485

### DIFF
--- a/src/tests/TestConsoleNetFramework/TestConsoleNetFramework.csproj
+++ b/src/tests/TestConsoleNetFramework/TestConsoleNetFramework.csproj
@@ -35,14 +35,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AggregatedGenericResultMessage, Version=1.3.3.6068, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AggregatedGenericResultMessage.1.3.3.6068\lib\net472\AggregatedGenericResultMessage.dll</HintPath>
+    <Reference Include="AggregatedGenericResultMessage, Version=1.3.4.6865, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AggregatedGenericResultMessage.1.3.4.6865\lib\net472\AggregatedGenericResultMessage.dll</HintPath>
     </Reference>
     <Reference Include="CodeSource, Version=1.0.6.933, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CodeSource.1.0.6.933\lib\net45\CodeSource.dll</HintPath>
     </Reference>
-    <Reference Include="DomainCommonExtensions, Version=1.1.1.7310, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DomainCommonExtensions.1.1.1.7310\lib\net45\DomainCommonExtensions.dll</HintPath>
+    <Reference Include="DomainCommonExtensions, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DomainCommonExtensions.1.3.0\lib\net45\DomainCommonExtensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
@@ -81,8 +81,8 @@
     <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Text.Encodings.Web.6.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=6.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Json.6.0.5\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=6.0.0.10, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Json.6.0.10\lib\net461\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -114,12 +114,10 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets" Condition="Exists('..\..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.1\build\Microsoft.Extensions.Logging.Abstractions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.1\build\Microsoft.Extensions.Logging.Abstractions.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.1\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.1\build\Microsoft.Extensions.Logging.Abstractions.targets')" />

--- a/src/tests/TestConsoleNetFramework/packages.config
+++ b/src/tests/TestConsoleNetFramework/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AggregatedGenericResultMessage" version="1.3.3.6068" targetFramework="net472" />
+  <package id="AggregatedGenericResultMessage" version="1.3.4.6865" targetFramework="net472" />
   <package id="CodeSource" version="1.0.6.933" targetFramework="net472" />
-  <package id="DomainCommonExtensions" version="1.1.1.7310" targetFramework="net472" />
+  <package id="DomainCommonExtensions" version="1.3.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="6.0.1" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
@@ -13,7 +13,7 @@
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
   <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net472" />
-  <package id="System.Text.Json" version="6.0.5" targetFramework="net472" />
+  <package id="System.Text.Json" version="6.0.10" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Upgrade minimum `System.Text.Json` package required version to `6.0.10`, fixing CVE (`CVE-2024-43485`)